### PR TITLE
프로젝트 전체 구조 다듬기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2211,6 +2212,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4568,6 +4578,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.1.tgz",
+      "integrity": "sha512-hPJXXxHJZEsPFNVbtATH7+MMX43UDeOauz+EAU4cgqTn7ojdI9qQORqS8Z0qmDlL1TclO/6jLRYUEtbWidtdHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.1.tgz",
+      "integrity": "sha512-vxU7ei//UfPYQ3iZvHuO1D/5fX3/JOqhNTbRR+WjSBWxf9bIvpWK+ftjmdfJHzPOuMQKe2fiEdG+dZX6E8uUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -4791,6 +4839,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 function App() {
-  return <></>;
+  return;
 }
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,15 @@
+import Routes from '@/routes/AppRouter';
+
 function App() {
-  return;
+  return (
+    <div>
+      {/*TODO: 헤더 컴포넌트 추가*/}
+      <main>
+        {/* 라우터에 의해 페이지가 랜더링 */}
+        <Routes />
+      </main>
+    </div>
+  );
 }
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,9 @@
 import Routes from '@/routes/AppRouter';
+import Style from '@/assets/styles/App.module.scss';
 
 function App() {
   return (
-    <div>
+    <div className={Style['app']}>
       {/*TODO: 헤더 컴포넌트 추가*/}
       <main>
         {/* 라우터에 의해 페이지가 랜더링 */}

--- a/src/assets/styles/App.module.scss
+++ b/src/assets/styles/App.module.scss
@@ -1,0 +1,4 @@
+.app {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/contexts/AppProvider.jsx
+++ b/src/contexts/AppProvider.jsx
@@ -2,6 +2,6 @@
 // 이 컴포넌트에 필요한 프로바이더를 추가하세요..
 import { ToastProvider } from './ToastProvider';
 
-export function AppProvider({ children }) {
+export default function AppProvider({ children }) {
   return <ToastProvider>{children}</ToastProvider>;
 }

--- a/src/contexts/AppProvider.jsx
+++ b/src/contexts/AppProvider.jsx
@@ -1,0 +1,7 @@
+// 다양한 컨텍스트를 제공하는 컴포넌트
+// 이 컴포넌트에 필요한 프로바이더를 추가하세요..
+import { ToastProvider } from './ToastProvider';
+
+export function AppProvider({ children }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,11 @@
-@use "@/assets/styles/reset";
-@use "@/assets/styles/font";
+@use '@/assets/styles/reset';
+@use '@/assets/styles/font';
+@use '@/assets/styles/variables';
+
+/* 글로벌 기본 스타일 */
+* {
+  box-sizing: border-box;
+}
 
 body {
   font-family: var(--font-family-base);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,9 @@
 import './index.scss';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App.jsx';
 import { BrowserRouter } from 'react-router-dom';
 import AppProvider from '@/contexts/AppProvider.jsx';
+import App from './App.jsx';
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,8 +6,10 @@ import { ToastProvider } from './contexts/ToastProvider.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ToastProvider>
-      <App />
-    </ToastProvider>
+    <BrowserRouter>
+      <AppProvider>
+        <App />
+      </AppProvider>
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,8 +2,8 @@ import './index.scss';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
-import { ToastProvider } from './contexts/ToastProvider.jsx';
-
+import { BrowserRouter } from 'react-router-dom';
+import AppProvider from '@/contexts/AppProvider.jsx';
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,0 +1,16 @@
+// src/pages/NotFoundPage.jsx
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+
+  return (
+    // TODO: BEM 및 scss 모듈 적용
+    <div style={{ textAlign: 'center', padding: '80px 20px' }}>
+      <h1>404</h1>
+      <p>페이지를 찾을 수 없습니다.</p>
+      <button onClick={() => navigate('/')}>홈으로 돌아가기</button>
+    </div>
+  );
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -1,0 +1,27 @@
+// src/router/index.jsx
+// 라우터를 조합해서 렌더링하는 컴포넌트
+
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { routes } from './routes';
+import { Suspense } from 'react';
+import NotFoundPage from '@/pages/NotFoundPage.jsx';
+//TODO: 로딩 컴포넌트 추가
+function Loading() {
+  return <div>Loading…</div>;
+}
+export default function AppRouter() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Routes>
+        {/* {라우터 배열에서 경로를 탐색함} */}
+        {routes.map(({ path, element: Component }) => (
+          <Route key={path} path={path} element={Component} />
+        ))}
+
+        {/* 매칭되는 경로가 없다면 notFound 페이지로 이동 */}
+        <Route path='*' element={<NotFoundPage />} />
+      </Routes>
+    </Suspense>
+  );
+}

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -1,0 +1,10 @@
+//import { lazy } from 'react';
+// 각 페이지의 주소와 컴포넌트를 매핑하는 라우트 설정 파일
+// lazy를 사용하면, 컴포넌트가 필요할 때만 불러와서 초기 로딩 속도를 개선할 수 있습니다.
+
+//ex): const PostPage = lazy(() => import('@/pages/PostPage/PostPage.jsx'));
+export const routes = [
+  // ex: { path: '/post', element: PostPage }, // 게시글 작성 페이지
+  //ex2: { path: '/list', element: ListPage },
+  // …추가 라우트
+];

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,7 +18,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         additionalData: `
-          @use "@/assets/styles/variables" as *;
+        
           @use "@/assets/styles/mixins" as *;
         `,
       },


### PR DESCRIPTION
## ✨ 작업 내용


- AppProvider를 제작했습니다.
> 해당 프로바이더를 통해, 다양한 Provider을 주입하시면 됩니다.
main.jsx에서는 단순하게 AppProvider로 감싸져 표시됩니다.
```jsx
// AppProvider 컴포넌트
export default function AppProvider({ children }) {
  return <ToastProvider>{children}</ToastProvider>;
}
// main에서 사용
   <BrowserRouter>
      <AppProvider>
        <App />
      </AppProvider>
    </BrowserRouter>

```

- router를 분리하여 AppRouter.jsx와 routes.js 파일로 분리했습니다.
 >- routes.js는 각 페이지의 컴포넌트와 path만을 저장하는 곳입니다. 
 >- AppRouter는 routes를 불러와서, 실제 화면에 렌더링합니다. 맞는 path가 없다면 자동으로 NotFoundPage로 리다이렉트 됩니다.
 >- 데이터를 불러오는 동안  `<Suspense fallback={<Loading />}>`을 통해 로딩하도록 했는데 추후에 로딩 스피너 등으로 변경하면 될것 같습니다.
 
- vite.config.js에서 variables.scss를 제거했습니다. 대신, index.scss에서 불러옵니다.
 >-  이는 불필요한 곳에서까지 중복적으로 변수 파일이 불러오는 문제를 해결하기 위함입니다.
 >- 대신, scss변수(`$변수` 형태)를 불러올때는 각 모듈 scss 파일에서 `@use`로 불러오셔야 합니다.
 >- * `npm run build`로 빌드 후 배포하게 되면 컴파일러가 중복 요소들을 자동으로 정리해서 `variables.scss`가 중복적으로 불러와지지는 않았었습니다. 그래서 해당 문제를 고려하지 못했던거 같습니다 ㅠㅠ

## 🔗 관련 이슈



Fixes #26 
