### PR TITLE
[Feat] 공용컴포넌트 Toggle 제작

### DIFF
--- a/src/components/OptionToggle.jsx
+++ b/src/components/OptionToggle.jsx
@@ -8,6 +8,8 @@ const OptionToggle = ({ children, onChange }) => {
   const [indicatorPosition, setIndicatorPosition] = useState(0);
 
   useEffect(() => {
+    if (selected !== null) return;
+
     const firstChild = Array.isArray(children) ? children[0] : children;
     const defaultType = firstChild?.props?.type;
     setSelected(defaultType);

--- a/src/components/OptionToggle.jsx
+++ b/src/components/OptionToggle.jsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import styles from './OptionToggle.module.scss';
+
+const OptionToggleContext = createContext();
+
+const OptionToggle = ({ children }) => {
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    const firstChild = Array.isArray(children) ? children[0] : children;
+    const defaultType = firstChild?.props?.type;
+    setSelected(defaultType);
+  }, []);
+
+  return (
+    <OptionToggleContext.Provider value={{ selected, setSelected }}>
+      <div className={styles['container']}>{children}</div>
+    </OptionToggleContext.Provider>
+  );
+};
+
+const OptionButton = ({ label, type }) => {
+  const { selected, setSelected } = useContext(OptionToggleContext);
+
+  const selectedButtonStyle = selected === type ? 'selected' : '';
+
+  const handleButtonClick = () => {
+    setSelected(type);
+  };
+
+  return (
+    <button
+      className={`${styles['button']} ${styles[selectedButtonStyle]}`}
+      onClick={handleButtonClick}
+    >
+      {label}
+    </button>
+  );
+};
+
+OptionToggle.button = OptionButton;
+
+export default OptionToggle;

--- a/src/components/OptionToggle.jsx
+++ b/src/components/OptionToggle.jsx
@@ -1,39 +1,54 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { Children, cloneElement, createContext, useContext, useEffect, useState } from 'react';
 import styles from './OptionToggle.module.scss';
 
 const OptionToggleContext = createContext();
 
-const OptionToggle = ({ children }) => {
+const OptionToggle = ({ children, onChange }) => {
   const [selected, setSelected] = useState(null);
+  const [indicatorPosition, setIndicatorPosition] = useState(0);
 
   useEffect(() => {
     const firstChild = Array.isArray(children) ? children[0] : children;
     const defaultType = firstChild?.props?.type;
     setSelected(defaultType);
-  }, []);
+    onChange?.(defaultType);
+  }, [children]);
+
+  const childrenAppendIndex = Children.map(children, (child, index) => {
+    return cloneElement(child, { index });
+  });
 
   return (
-    <OptionToggleContext.Provider value={{ selected, setSelected }}>
-      <div className={styles['container']}>{children}</div>
+    <OptionToggleContext.Provider value={{ selected, setSelected, setIndicatorPosition, onChange }}>
+      <div className={styles['container']}>
+        {childrenAppendIndex}
+        <div
+          className={styles['indicator']}
+          style={{ transform: `translateX(${indicatorPosition}px)` }}
+        />
+      </div>
     </OptionToggleContext.Provider>
   );
 };
 
-const OptionButton = ({ label, type }) => {
-  const { selected, setSelected } = useContext(OptionToggleContext);
+const OptionButton = ({ index, label, type }) => {
+  const { selected, setSelected, setIndicatorPosition, onChange } = useContext(OptionToggleContext);
 
   const selectedButtonStyle = selected === type ? 'selected' : '';
 
   const handleButtonClick = () => {
     setSelected(type);
+    setIndicatorPosition(index * 122);
+    onChange?.(type);
   };
 
   return (
-    <button
-      className={`${styles['button']} ${styles[selectedButtonStyle]}`}
-      onClick={handleButtonClick}
-    >
-      {label}
+    <button className={`${styles['button']}`} onClick={handleButtonClick}>
+      <span
+        className={`${styles['button-label']}  ${selected === type ? styles[selectedButtonStyle] : ''}`}
+      >
+        {label}
+      </span>
     </button>
   );
 };

--- a/src/components/OptionToggle.module.scss
+++ b/src/components/OptionToggle.module.scss
@@ -1,0 +1,32 @@
+.container {
+	display: flex;
+	flex-direction: row;
+	background-color: var(--color-gray-100);
+	border-radius: 6px;
+	height: 40px;
+	width: fit-content;
+}
+
+.button {
+	width: 122px;
+	background: none;
+	border: none;
+	font-weight: 400;
+	font-size: 16px;
+	line-height: 26px;
+	color: var(--color-gray-900);
+	border-radius: 6px;
+	cursor: pointer;
+
+	&.selected {
+		border: 2px solid var(--color-purple-600);
+		border-radius: 6px;
+		font-weight: 700;
+		color: var(--color-purple-700);
+		background-color: var(--color-white);
+	}
+
+	&:hover {
+		background-color: var(--color-gray-200);
+	}
+}

--- a/src/components/OptionToggle.module.scss
+++ b/src/components/OptionToggle.module.scss
@@ -5,28 +5,43 @@
 	border-radius: 6px;
 	height: 40px;
 	width: fit-content;
+	position: relative;
 }
 
 .button {
 	width: 122px;
 	background: none;
 	border: none;
-	font-weight: 400;
-	font-size: 16px;
-	line-height: 26px;
-	color: var(--color-gray-900);
 	border-radius: 6px;
 	cursor: pointer;
+	position: relative;
+}
 
-	&.selected {
-		border: 2px solid var(--color-purple-600);
-		border-radius: 6px;
-		font-weight: 700;
-		color: var(--color-purple-700);
-		background-color: var(--color-white);
-	}
+.button-label {
+	font-weight: 400;
+	font-size: 16px;
+	color: var(--color-gray-900);
+	position: absolute;
+	z-index: 1;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%,-50%);
+	transition: color 0.3s ease;
+	transition: font-weight 0.3s ease;
+}
 
-	&:hover {
-		background-color: var(--color-gray-200);
-	}
+.selected {
+	color: var(--color-purple-700);
+	font-weight: 700;
+}
+
+.indicator {
+	border: 2px solid var(--color-purple-600);
+	border-radius: 6px;
+	background-color: var(--color-white);
+	width: 122px;
+	height: 40px;
+	position: absolute;
+	top: 0;
+	transition: transform 0.3s ease, width 0.3s ease;
 }


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->

조금 수정해야 할 내용이 있지만 저녁에 잠깐 나가봐야할 일이있어서 일단 급하게 PR 올립니다!
반영 후 추가로 멘션 드리겠습니다 :)

- 공용 컴포넌트 OptionToggle.jsx 제작

### 💡 Toggle 사용 방법

#### OptionToggle.jsx는 합성컴포넌트 입니다.
- 부모 컴포넌트에서 요소를 조립해 사용 할 수 있습니다.
- 부모 컴포넌트의 set함수를 onChange Prop의 콜백함수로 전달하여 OptionToggle의 선택값을 받아 올 수 있습니다.
- OptionToggle.button의 type props는 key로 사용됩니다.
```js
{/*부모 컴포넌트*/}

  const [bgType, setBgType] = useState(null);
...
      <OptionToggle onChange={(type) => setBgType(type)}>
        <OptionToggle.button label='컬러' type='color' />
        <OptionToggle.button label='이미지' type='image' />
      </OptionToggle>
```
OptionToggle.button 갯수를 더 추가해서 사용할 수 있습니다.
```js
      <OptionToggle onChange={(type) => setBgType(type)}>
        <OptionToggle.button label='컬러' type='color' />
        <OptionToggle.button label='이미지' type='image' />
        <OptionToggle.button label='없음' type='none' /> {/*임시 추가한 컴포넌트*/}
      </OptionToggle>
```
![image](https://github.com/user-attachments/assets/833f080f-60a6-4350-8406-3712c6714cda)

### 💡 최종 결과물
애니메이션을 적용하였습니다.
![Animation](https://github.com/user-attachments/assets/9f74470d-ed91-47be-8f17-a9b72c53d485)

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #34 
