### PR TITLE
[Fix] mixins 경고 내용 수정

### DIFF
--- a/src/assets/styles/_mixins.scss
+++ b/src/assets/styles/_mixins.scss
@@ -1,6 +1,9 @@
 // width 반응형 설정
 @mixin responsive-width($mobile, $tablet, $desktop) {
-  width: $mobile;
+  & {
+		width: $mobile;
+	}
+	
 
   @media screen and (min-width: 768px) and (max-width: 1247px) {
     width: $tablet;


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
scss 선언 관련 경고 내용을 수정하였습니다.
![image](https://github.com/user-attachments/assets/5d68ec07-516c-43bc-b4fa-492545cdaf26)

- before
```css
@mixin responsive-width($mobile, $tablet, $desktop) {
  width: $mobile;

  @media screen and (min-width: 768px) and (max-width: 1247px) {
    width: $tablet;
  }

  @media (min-width: 1248px) {
    width: $desktop;
  }
}
```
```css
@mixin responsive-width($mobile, $tablet, $desktop) {
  & {
    width: $mobile;
  }
	
  @media screen and (min-width: 768px) and (max-width: 1247px) {
    width: $tablet;
  }

  @media (min-width: 1248px) {
    width: $desktop;
  }
}
```

- after
-

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
