### PR TITLE
헤더에서 루트 페이지로 이동이 가능하도록 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,6 @@ import GlobalHeader from '@/components/Header/GlobalHeader';
 function App() {
   return (
     <div className={Style['app']}>
-      <GlobalHeader />
       <main>
         {/* 라우터에 의해 페이지가 랜더링 */}
         <Routes />

--- a/src/components/Header/GlobalHeader.jsx
+++ b/src/components/Header/GlobalHeader.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import LOGO from '@/assets/logo/Logo-Rolling.png';
 import Style from './GlobalHeader.module.scss';
 import useShowComponent from '@/hooks/useShowComponent';
@@ -27,7 +27,10 @@ function GlobalHeader() {
   return (
     <header className={Style['header']}>
       <div className={Style['header__container']}>
-        <img src={LOGO} alt='Logo' className={Style['header__logo']} />
+        {/*  루트로 이동*/}
+        <Link to='/' className={Style['header__logo-link']}>
+          <img src={LOGO} alt='Logo' className={Style['header__logo']} />
+        </Link>
         {/* todo: 디자인시스템 버튼으로 교체 */}
         {showButton && (
           <button

--- a/src/components/Header/GlobalHeader.module.scss
+++ b/src/components/Header/GlobalHeader.module.scss
@@ -12,7 +12,16 @@
     justify-content: space-between;
     padding: 0 24px;
   }
+  &__logo-link {
+    padding: 6px 12px;
+    border-radius: 6px;
+    transition: background-color 0.2s ease-in-out;
+    cursor: pointer;
 
+    &:hover {
+      background-color: var(--color-gray-100);
+    }
+  }
   &__logo {
     height: 30px;
   }

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -8,6 +8,7 @@ import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import NotFoundPage from '@/pages/NotFoundPage.jsx';
 import ErrorPage from '@/pages/ErrorPage.jsx';
+import GlobalHeader from '@/components/Header/GlobalHeader.jsx';
 //TODO: 로딩 컴포넌트 추가
 function Loading() {
   return <div>Loading…</div>;
@@ -19,6 +20,7 @@ export default function AppRouter() {
     // ErrorBoundary를 사용하여 에러가 발생했을 때 대체 UI를 보여줌
     <ErrorBoundary FallbackComponent={ErrorPage} resetKeys={[location.pathname]}>
       <Suspense fallback={<Loading />}>
+        <GlobalHeader />
         <Routes>
           {/* 라우터 배열에서 경로를 탐색함 */}
           {routes.map(({ path, element: Page }) => (


### PR DESCRIPTION
## ✨ 작업 내용


- GlobalHeader가 에러 바운더리 안에 들어갑니다.
- 로고를 클릭하면 호버 효과가 적용되고, 루트 페이지로 이동이 가능합니다.
<img width="127" alt="image" src="https://github.com/user-attachments/assets/f6be0b9c-a083-413c-b2dd-2da34273871c" />


## 🔗 관련 이슈



Fixes #60
