### PR TITLE
[Fix] Textfield 컴포넌트 messageProps로 변경 및 등록 페이지 텍스트 필드에 반영

### DIFF
--- a/src/components/Textfield.jsx
+++ b/src/components/Textfield.jsx
@@ -7,7 +7,7 @@ import styles from '@/components/Textfield.module.scss';
   
   [Textfield 상태 속성]
   - disabled: 비활성화 상태
-  - isError: 에러 또는 성공 상태 => true 또는 false 값을 넘긴다.
+  - isValid: 에러 또는 성공 상태 => true 또는 false 값을 넘긴다.
   - message: 메세지가 있는 경우 출력
 */
 
@@ -15,21 +15,24 @@ const Textfield = ({
   value,
   placeholder = '입력해주세요',
   onChange,
-  isValid,
+  isValid = null,
   message,
   disabled,
+  ...rest
 }) => {
   const statusClass = {
+    null: '',
     false: 'textfield--error',
     true: 'textfield--success',
   };
 
   const statusMessageClass = {
+    null: '',
     false: 'textfield__message--error',
     true: 'textfield__message--success',
   };
 
-  const showMessage = !disabled && !isValid && message;
+  const showMessage = !disabled && isValid === false && message;
 
   return (
     <>
@@ -41,10 +44,11 @@ const Textfield = ({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           className={`${styles['textfield']} ${styles[statusClass[isValid]]} `}
+          {...rest}
         />
         {showMessage && (
           <div className={`${styles['textfield__message']} ${styles[statusMessageClass[isValid]]}`}>
-            {message}
+            {message + isValid}
           </div>
         )}
       </div>

--- a/src/components/Textfield.jsx
+++ b/src/components/Textfield.jsx
@@ -7,8 +7,9 @@ import styles from '@/components/Textfield.module.scss';
   
   [Textfield 상태 속성]
   - disabled: 비활성화 상태
-  - isValid: 에러 또는 성공 상태 => true 또는 false 값을 넘긴다.
+  - isValid: 에러 또는 성공 상태 => null(초기상태). true 또는 false 값을 넘긴다.
   - message: 메세지가 있는 경우 출력
+  - messageProps: isShow로 메시지를 보여줄지 여부 결정, text로 메시지 내용 전달
 */
 
 const Textfield = ({
@@ -16,8 +17,8 @@ const Textfield = ({
   placeholder = '입력해주세요',
   onChange,
   isValid = null,
-  message,
   disabled,
+  messageProps = { isShow: false, text: '' },
   ...rest
 }) => {
   const statusClass = {
@@ -32,7 +33,7 @@ const Textfield = ({
     true: 'textfield__message--success',
   };
 
-  const showMessage = !disabled && isValid === false && message;
+  const showMessage = messageProps?.isShow;
 
   return (
     <>
@@ -48,7 +49,7 @@ const Textfield = ({
         />
         {showMessage && (
           <div className={`${styles['textfield__message']} ${styles[statusMessageClass[isValid]]}`}>
-            {message + isValid}
+            {messageProps.text}
           </div>
         )}
       </div>

--- a/src/components/Textfield.jsx
+++ b/src/components/Textfield.jsx
@@ -9,7 +9,6 @@ import styles from '@/components/Textfield.module.scss';
   - disabled: 비활성화 상태
   - isValid: 에러 또는 성공 상태 => null(초기상태). true 또는 false 값을 넘긴다.
   - message: 메세지가 있는 경우 출력
-  - messageProps: isShow로 메시지를 보여줄지 여부 결정, text로 메시지 내용 전달
 */
 
 const Textfield = ({
@@ -18,7 +17,8 @@ const Textfield = ({
   onChange,
   isValid = null,
   disabled,
-  messageProps = { isShow: false, text: '' },
+  message,
+  className,
   ...rest
 }) => {
   const statusClass = {
@@ -33,7 +33,7 @@ const Textfield = ({
     true: 'textfield__message--success',
   };
 
-  const showMessage = messageProps?.isShow;
+  const showMessage = !disabled && message;
 
   return (
     <>
@@ -44,12 +44,12 @@ const Textfield = ({
           disabled={disabled}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className={`${styles['textfield']} ${styles[statusClass[isValid]]} `}
+          className={`${className} ${styles['textfield']} ${styles[statusClass[isValid]]} `}
           {...rest}
         />
         {showMessage && (
           <div className={`${styles['textfield__message']} ${styles[statusMessageClass[isValid]]}`}>
-            {messageProps.text}
+            {message}
           </div>
         )}
       </div>

--- a/src/components/Textfield.module.scss
+++ b/src/components/Textfield.module.scss
@@ -10,13 +10,13 @@
   color: var(--color-gray-500);
 
   &:hover {
-    border: 1px solid var(--color-gray-500);
+    border: 1px solid var(--color-purple-500);
     color: var(--color-gray-500);
   }
 
   &:focus,
   &:active {
-    border: 2px solid var(--color-gray-500);
+    border: 2px solid var(--color-purple-500);
     color: var(--color-gray-900);
   }
 

--- a/src/pages/CreateRollingPaperPage/components/ReceiverInputField.jsx
+++ b/src/pages/CreateRollingPaperPage/components/ReceiverInputField.jsx
@@ -4,22 +4,16 @@ import Textfield from '@/components/Textfield';
 
 const ReceiverInputField = ({ receiver, setReceiver }) => {
   const [isValid, setIsValid] = useState(null);
-  const [messageProps, setMessageProps] = useState({});
+  const [message, setMessage] = useState('');
 
   // input change event
   const handleInputChange = (value) => {
     if (!value) {
       setIsValid(false);
-      setMessageProps({
-        isShow: true,
-        text: '이름이 입력되지 않았습니다',
-      });
+      setMessage('이름이 입력되지 않았습니다');
     } else {
       setIsValid(true);
-      setMessageProps({
-        isShow: false,
-        text: '',
-      });
+      setMessage('');
     }
     setReceiver(value);
   };
@@ -32,7 +26,7 @@ const ReceiverInputField = ({ receiver, setReceiver }) => {
         placeholder='받는 사람 이름을 입력해주세요'
         onChange={handleInputChange}
         isValid={isValid}
-        messageProps={messageProps}
+        message={message}
       />
     </article>
   );

--- a/src/pages/CreateRollingPaperPage/components/ReceiverInputField.jsx
+++ b/src/pages/CreateRollingPaperPage/components/ReceiverInputField.jsx
@@ -4,11 +4,23 @@ import Textfield from '@/components/Textfield';
 
 const ReceiverInputField = ({ receiver, setReceiver }) => {
   const [isValid, setIsValid] = useState(null);
+  const [messageProps, setMessageProps] = useState({});
 
   // input change event
   const handleInputChange = (value) => {
-    if (!value) setIsValid(false);
-    else setIsValid(true);
+    if (!value) {
+      setIsValid(false);
+      setMessageProps({
+        isShow: true,
+        text: '이름이 입력되지 않았습니다',
+      });
+    } else {
+      setIsValid(true);
+      setMessageProps({
+        isShow: false,
+        text: '',
+      });
+    }
     setReceiver(value);
   };
 
@@ -20,7 +32,7 @@ const ReceiverInputField = ({ receiver, setReceiver }) => {
         placeholder='받는 사람 이름을 입력해주세요'
         onChange={handleInputChange}
         isValid={isValid}
-        message='이름이 입력되지 않았습니다'
+        messageProps={messageProps}
       />
     </article>
   );


### PR DESCRIPTION
## ✨ 작업 내용
- 텍스트필드 컴포넌트에 rest로 나머지 props 받아오도록 추가
- 기존 `message`만 받아오던 방식에서, `messageProps`로 변경 { isShow: false, text: '' },
- messageProps의 isShow가 true일때만 메세지 보이게 변경
- 치영님이 작업하신 등록페이지 내 ReceiverInputField에 messageProps 추가하여 반영


```const ReceiverInputField = ({ receiver, setReceiver }) => {
  const [isValid, setIsValid] = useState(null);
  const [messageProps, setMessageProps] = useState({});

  // input change event
  const handleInputChange = (value) => {
    if (!value) {
      setIsValid(false);
      setMessageProps({
        isShow: true,
        text: '이름이 입력되지 않았습니다',
      });
    } else {
      setIsValid(true);
      setMessageProps({
        isShow: false,
        text: '',
      });
    }
    setReceiver(value);
  };

  return (
    <article className={styles['receiver-field']}>
      <label className={styles['receiver-field__label']}>To.</label>
      <Textfield
        value={receiver}
        placeholder='받는 사람 이름을 입력해주세요'
        onChange={handleInputChange}
        isValid={isValid}
        messageProps={messageProps}
      />
    </article>
  );
};
```

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
