### PR TITLE
feat: listReception가 boolean으로 sortLike를 받습니다. 

### DIFF
--- a/src/apis/recipientsApi.js
+++ b/src/apis/recipientsApi.js
@@ -13,7 +13,7 @@ export const TEAM = '2';
  * @param {Object}  [params]             - 페이지네이션 옵션 객체
  * @param {number}  [params.limit=20]    - **가져올 개수** (page size)
  * @param {number}  [params.offset=0]    - **시작 인덱스** (0부터)
- *
+ * @param {boolean} [params.sortLike=false]  - `true`면 reactionCount 순으로 정렬 (`sort=like`)
  * @returns {Promise<{
  *   count: number,                // 총 Recipient 개수
  *   next: string|null,            // 다음 페이지 URL (없으면 null)
@@ -31,9 +31,9 @@ export const TEAM = '2';
  *   }>
  * }>}
  */
-export const listRecipients = ({ limit = 20, offset = 0 } = {}) =>
+export const listRecipients = ({ limit = 20, offset = 0, sortLike = false } = {}) =>
   httpClient.get(`/${TEAM}/recipients/`, {
-    params: { limit, offset },
+    params: { limit, offset, ...(sortLike && { sort: 'like' }) },
   });
 
 /**


### PR DESCRIPTION
## ✨ 작업 내용

- `sortLike = true` 로 넘겨줄 경우  해당 param을 추가합니다.
- 기본값으로 false로 되어있어서, reactionCount순으로 넘겨줄 필요가 없는 경우 해당 파라미터를 넣지 않아도 됩니다.

### 변경 코드

```js
/**
 * 팀 내 Recipient(롤링페이퍼) 목록 가져오기
 *
 * @param {Object}  [params]             - 페이지네이션 옵션 객체
 * @param {number}  [params.limit=20]    - **가져올 개수** (page size)
 * @param {number}  [params.offset=0]    - **시작 인덱스** (0부터)
 * @param {boolean} [params.sortLike=false]  - `true`면 reactionCount 순으로 정렬 (`sort=like`) 
 * @returns {Promise<{
 *   count: number,                // 총 Recipient 개수
 *   next: string|null,            // 다음 페이지 URL (없으면 null)
 *   previous: string|null,        // 이전 페이지 URL (없으면 null)
 *   results: Array<{
 *     id: number,
 *     name: string,
 *     backgroundColor: string,
 *     backgroundImageURL: string,
 *     createdAt: string,
 *     messageCount: number,
 *     recentMessages: Array,
 *     reactionCount: number,
 *     topReactions: Array
 *   }>
 * }>}
 */
export const listRecipients = ({ limit = 20, offset = 0, sortLike = false } = {}) =>
  httpClient.get(`/${TEAM}/recipients/`, {
    params: { limit, offset, ...(sortLike && { sort: 'like' }) },
  });
```

## 🔗 관련 이슈



Fixes #86 
