### PR TITLE
[Fix] Modal, ToastProvider 구조 변경

### DIFF
--- a/src/components/PostHeader/PostHeader.jsx
+++ b/src/components/PostHeader/PostHeader.jsx
@@ -10,6 +10,7 @@ import ShareMenu from '@/components/PostHeader/ShareMenu/ShareMenu';
 
 import { useDeviceType } from '@/hooks/useDeviceType';
 import { DEVICE_TYPES } from '@/constants/deviceType';
+import { useKakaoShare } from '../../hooks/useKakaoShare';
 
 /**
  * PostHeader 컴포넌트
@@ -24,6 +25,9 @@ export default function PostHeader({ id, name }) {
   // 현재 디바이스 타입을 가져옴
   const deviceType = useDeviceType();
   const isDesktop = deviceType === DEVICE_TYPES.DESKTOP;
+
+  // 카카오 공유 이벤트 핸들러
+  const { handleKakaoShare } = useKakaoShare();
 
   return (
     <header className={Style['post-header']}>
@@ -46,11 +50,7 @@ export default function PostHeader({ id, name }) {
 
           <div className={Style['post-header__divider']} />
 
-          <ShareMenu
-            onKakaoClick={() => {
-              /* 공유 로직 */
-            }}
-          />
+          <ShareMenu onKakaoClick={handleKakaoShare} />
         </nav>
       </div>
     </header>

--- a/src/contexts/AppProvider.jsx
+++ b/src/contexts/AppProvider.jsx
@@ -5,8 +5,8 @@ import { ModalProvider } from './ModalProvider';
 
 export default function AppProvider({ children }) {
   return (
-    <ModalProvider>
-      <ToastProvider>{children}</ToastProvider>
-    </ModalProvider>
+    <ToastProvider>
+      <ModalProvider>{children}</ModalProvider>
+    </ToastProvider>
   );
 }

--- a/src/contexts/ModalProvider.jsx
+++ b/src/contexts/ModalProvider.jsx
@@ -13,6 +13,9 @@ export const ModalProvider = ({ children }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
 
+  const modalWrapperRef = useRef(null);
+  const isMouseDownInsideModal = useRef(false);
+
   const location = useLocation();
 
   const closeTimeoutRef = useRef(null);
@@ -48,6 +51,35 @@ export const ModalProvider = ({ children }) => {
 
   useEffect(() => {
     if (!isOpen) return;
+    const handleMouseDown = (e) => {
+      if (modalWrapperRef.current?.contains(e.target)) {
+        isMouseDownInsideModal.current = true;
+      } else {
+        isMouseDownInsideModal.current = false;
+      }
+    };
+
+    const handleMouseUp = (e) => {
+      if (
+        !modalWrapperRef.current?.contains(e.target) &&
+        isMouseDownInsideModal.current === false
+      ) {
+        closeModal();
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isOpen]);
+
+  //Modal이 열렸을 때 esc를 누르면 Modal Close
+  useEffect(() => {
+    if (!isOpen) return;
 
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') {
@@ -61,6 +93,7 @@ export const ModalProvider = ({ children }) => {
     };
   }, [isOpen]);
 
+  //페이지 주소가 이동되면 Modal 강제 종료
   useEffect(() => {
     if (!isOpen) return;
     closeModalImmediately();
@@ -71,13 +104,11 @@ export const ModalProvider = ({ children }) => {
       {children}
       {isOpen > 0 &&
         createPortal(
-          <div
-            className={`${styles['modal-background']} ${styles[isClosing ? 'isClosing' : '']}`}
-            onClick={closeModal}
-          >
+          <div className={`${styles['modal-background']} ${styles[isClosing ? 'isClosing' : '']}`}>
             <div
               className={`${styles['modal-wrapper']} ${styles[isClosing ? 'isClosing' : '']}`}
               onClick={(e) => e.stopPropagation()}
+              ref={modalWrapperRef}
             >
               {modal}
             </div>

--- a/src/contexts/ToastProvider.module.scss
+++ b/src/contexts/ToastProvider.module.scss
@@ -7,6 +7,7 @@ $wrapper-width-desktop: 524px;
 	height: 64px;
 	bottom: 70px;
 	left: 50%;
+	z-index: 99999;
 	transform: translateX(-50%);
 	> * {
 		position: absolute;

--- a/src/hooks/useKakaoShare.jsx
+++ b/src/hooks/useKakaoShare.jsx
@@ -19,7 +19,7 @@ export const useKakaoShare = () => {
       },
       buttons: [
         {
-          title: '롤링 보러가기',
+          title: '롤링페이퍼 보러가기',
           link: {
             mobileWebUrl: currentUrl,
             webUrl: currentUrl,

--- a/src/hooks/useKakaoShare.jsx
+++ b/src/hooks/useKakaoShare.jsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+
+export const useKakaoShare = () => {
+  const handleKakaoShare = () => {
+    if (!window.Kakao || !window.Kakao.isInitialized()) return;
+    const currentUrl = window.location.href;
+    const origin = window.location.origin;
+    const imageUrl = `${origin}/images/image_opengraph.png`;
+    window.Kakao.Share.sendDefault({
+      objectType: 'feed',
+      content: {
+        title: '🎉 롤링페이퍼가 도착했어요!',
+        description: '친구의 따뜻한 메시지를 확인해보세요.',
+        imageUrl: imageUrl,
+        link: {
+          mobileWebUrl: currentUrl,
+          webUrl: currentUrl,
+        },
+      },
+      buttons: [
+        {
+          title: '롤링 보러가기',
+          link: {
+            mobileWebUrl: currentUrl,
+            webUrl: currentUrl,
+          },
+        },
+      ],
+    });
+  };
+
+  useEffect(() => {
+    const JS_APP_KEY = import.meta.env.VITE_KAKAO_JS_KEY;
+    const kakaoSdkUrl = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js';
+    const integrityValue =
+      'sha384-dok87au0gKqJdxs7msEdBPNnKSRT+/mhTVzq+qOhcL464zXwvcrpjeWvyj1kCdq6';
+
+    // 이미 로드되었는지 확인
+    if (window.Kakao) {
+      if (!window.Kakao.isInitialized()) {
+        window.Kakao.init(JS_APP_KEY);
+      }
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = kakaoSdkUrl;
+    script.integrity = integrityValue;
+    script.crossOrigin = 'anonymous';
+    script.onload = () => {
+      if (window.Kakao && !window.Kakao.isInitialized()) {
+        window.Kakao.init(JS_APP_KEY);
+      }
+    };
+    document.head.appendChild(script);
+  }, []);
+
+  return { handleKakaoShare };
+};


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->

현재 카카오톡 공유 기능 추가 건과 commit이 합쳐져있습니다.
아래 3가지 파일만 봐주시면 됩니다!

1. ModalProvider
2. AppProvider
3. ToastProvider

### 💡 ModalProvier.jsx 수정
기존에 Modal 내부에서 클릭 유지 후 Modal 외부로 이동하여 클릭을 해제하면 Modal이 Close 되고,
Modal 외부 클릭 유지 후 Modal 내부로 이동하여 클릭을 해제하면 Modal이 Close 되는 문제가 있었습니다.

해당 문제를 수정하였습니다.

이해를 돕기 위해 이미지를 첨부합니다.
![Animation](https://github.com/user-attachments/assets/b75f9d47-1b76-4fed-9c41-5fd9cc99cb0f)

### 💡AppProvider 수정
ColorPicker Modal에서 선택한 색을 복사하는 기능을 만들고, 복사에 성공했을 때 toast를 띄울 예정입니다.
따라서 ToastProvider가 ModalProvider의 상위에 위치하도록 수정했습니다.

이해를 돕기 위해 이미지를 첨부합니다.
![Animation](https://github.com/user-attachments/assets/046d48ba-dd68-4a65-95cd-e8599506ffc7)

### 💡ToastProvider 수정
Modal이 열린 상태에서 Toast가 띄워지면 Modal보다 위에 위치해야하기 때문에 z-index를 Modal보다 높게 설정하였습니다.
Modal: z-index 9999
Toast: z-index 99999

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
