### PR TITLE
[Fix] POST 페이지 ReceiverField 스타일 미적용 문제 수정

### DIFF
--- a/src/components/Textfield.module.scss
+++ b/src/components/Textfield.module.scss
@@ -59,7 +59,7 @@
 .textfield__message {
   font-size: var(--font-size-12);
   margin-top: 4px;
-
+	margin-left: 10px;
   &--error {
     color: var(--color-error);
   }

--- a/src/pages/CreateRollingPaperPage/components/ReceiverField.jsx
+++ b/src/pages/CreateRollingPaperPage/components/ReceiverField.jsx
@@ -33,6 +33,7 @@ const ReceiverField = ({ formDataChange }) => {
         message={messageByValid[isInputValid]}
         value={inputValue}
         onChange={handleInputChange}
+        isValid={isInputValid}
       />
     </article>
   );


### PR DESCRIPTION
…스타일 변경

## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->

- ReceiverField에 isValid props 누락 되어 스타일 적용 안되던 문제 수정

---
추가 수정 내용
- Textfield 컴포넌트의 message 요소에 스타일 추가 (margin-left: 10px;)

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
