### PR TITLE
[Hotfix]: POST페이지에서 커스텀이미지 선택 후 롤링페이퍼 생성할때 request 오류 발생 현상 수정

### DIFF
--- a/src/pages/CreateRollingPaperPage/components/ImagePickArea.jsx
+++ b/src/pages/CreateRollingPaperPage/components/ImagePickArea.jsx
@@ -29,16 +29,17 @@ const ImagePickArea = ({ formDataChange, setNewImageFileObject, showImagePickAre
 
     setCustomImageFileList((prev) => {
       const next = [file, ...prev];
+      setNewImageFileObject(next[0]);
       return next.slice(0, 3);
     });
 
     setCustomImagePreviewUrlList((prev) => {
       const next = [newUrl, ...prev];
+      setSelectedImageUrl(next[0]);
       if (next.length > 3) {
         const urlToRevoke = next[next.length - 1];
         URL.revokeObjectURL(urlToRevoke);
       }
-      handleImageSelect(next[0]);
       return next.slice(0, 3);
     });
   };


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
## 💡ImagePickArea
- 로컬에서 이미지 선택 후 state 관리 로직 수정

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #123
