### PR TITLE
[Fix] 태블릿 이하에서 무한스크롤 감지 오류 수정, 초기 스크롤 위치 초기화

### DIFF
--- a/src/hooks/useMessageItemsList.jsx
+++ b/src/hooks/useMessageItemsList.jsx
@@ -42,6 +42,11 @@ export const useMessageItemsList = (id) => {
   /* 초기 호출인지 확인 */
   const isFirstCall = offset === 0;
 
+  /* 스크롤 위치 초기화 */
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   /* API 실행 후 데이터 세팅 */
   useEffect(() => {
     if (messageLoading || !messageList) return;
@@ -68,7 +73,7 @@ export const useMessageItemsList = (id) => {
 
   /* 스크롤 시 데이터 다시 불러옴  */
   const loadMore = () => {
-    if (messageLoading || !hasNext) return;
+    if (messageLoading || !hasNext || itemList.length === 0) return;
     const newOffset = isFirstCall ? offset + 8 : offset + 6;
     getMessageListRefetch({ recipientId: id, limit: 6, offset: newOffset });
     setOffset(newOffset);


### PR DESCRIPTION
## ✨ 작업 내용

- 태블릿 이하에서 무한스크롤 하기 전에 API 호출되는 오류 수정 
- 롤링페이퍼 목록에서 아래로 스크롤 후 화면 이동 시 스크롤 위치를 위로 올림

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->

Fixes #
